### PR TITLE
Added support for additional authentication methods.

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"fmt"
+
 	"github.com/tkanos/gonfig"
 )
 
@@ -21,6 +23,13 @@ type Configuration struct {
 	USER_PASS_BASED_AUTH           bool
 	ROOT_PASSWORD                  string
 	DEBUG                          bool
+	AUTH_METHOD                    string // Either "jwt", "api_token" , "hmac_token" or "none".
+	API_TOKEN                      string // API token shared between the client and memphis-rest-gateway.
+	API_TOKEN_HEADER               string // Name of header that contains the API token.
+	HMAC_TOKEN_SECRET              string // A shared secret between the client and memphis-rest-gateway.
+	HMAC_TOKEN_HEADER              string // Name of header that contains the body signature which is a MAC hex digest of the body calcuated using the TOKEN_SECRET as the hash key.
+	HMAC_TOKEN_HASH                string // Hash algorithm for cacluating body signature, can be either sha256 or sha512.
+
 }
 
 func GetConfig() Configuration {
@@ -28,4 +37,49 @@ func GetConfig() Configuration {
 	gonfig.GetConf("./conf/config.json", &configuration)
 
 	return configuration
+}
+
+func Validate(configuration Configuration) error {
+
+	switch configuration.AUTH_METHOD {
+	case "jwt":
+		// JWT_EXPIRES_IN_MINUTES and REFRESH_JWT_EXPIRES_IN_MINUTES defaults to 0 if they are missing from configuration file.
+		// Don't know if that should generate an error or not.
+
+		if configuration.JWT_SECRET == "" {
+			return fmt.Errorf("configuration option JWT_SECRET is either the empty string or missing")
+		}
+		if configuration.REFRESH_JWT_SECRET == "" {
+			return fmt.Errorf("configuration option REFRESH_JWT_SECRET is either the empty string or missing")
+		}
+
+	case "api_token":
+		if configuration.API_TOKEN == "" {
+			return fmt.Errorf("configuration option API_TOKEN is either the empty string or missing")
+		}
+		if configuration.API_TOKEN_HEADER == "" {
+			return fmt.Errorf("configuration option API_TOKEN_HEADER is either the empty string or missing")
+		}
+
+	case "hmac_token":
+		if configuration.HMAC_TOKEN_SECRET == "" {
+			return fmt.Errorf("configuration option HMAC_TOKEN_SECRET is either the empty string or missing")
+		}
+		if configuration.HMAC_TOKEN_HEADER == "" {
+			return fmt.Errorf("configuration option HMAC_TOKEN_HEADER is either the empty string or missing")
+		}
+		if configuration.HMAC_TOKEN_HASH == "" {
+			return fmt.Errorf("configuration option HMAC_TOKEN_HMAC_HASH is either the empty string or missing")
+		}
+	case "none":
+		return nil
+	default:
+		if configuration.AUTH_METHOD == "" {
+			return nil
+		} else {
+			return fmt.Errorf("configuration option AUTH_METHOD has to be either 'jwt', 'api_token', 'hmac_token' or 'none'")
+		}
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,12 @@ import (
 
 func main() {
 	configuration := conf.GetConfig()
+	err := conf.Validate(configuration)
+	if err != nil {
+		fmt.Printf("Configuration error: %v", err)
+		return
+	}
+
 	var conn *memphis.Conn
 	ticker := time.NewTicker(1 * time.Second)
 	for {


### PR DESCRIPTION
A user is able to use the AUTH_METHOD configuration directive to select between four authentication methods, jwt which is the default method , api-token, hmac hex digest as well as none for no authentication method at all.
It should be backward compatible with older configurations.