### PR TITLE
Stations can be configured to use their own specific authentication method

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -1,31 +1,151 @@
 package conf
 
 import (
-	"github.com/tkanos/gonfig"
+	"fmt"
 )
 
+type JWT_Config struct {
+	JWT_SECRET                     string // The secret key used to generate the JWT token.
+	JWT_EXPIRES_IN_MINUTES         int    // The JWT token valid time in minutes.
+	REFRESH_JWT_SECRET             string // The secret key used to generate the JWT refresh token.
+	REFRESH_JWT_EXPIRES_IN_MINUTES int    // The JWT refresh token valid time in minutes.
+}
+
+type API_Token_Config struct {
+	API_TOKEN_HEADER string // Name of header that contains the API token.
+	API_TOKEN        string // API token shared between the client and memphis-rest-gateway.
+
+	HMAC_TOKEN_HEADER string // Name of header of the body signature. The body signature is a MAC hex digest of the body calcuated using the TOKEN_SECRET as the hash key.
+	HMAC_TOKEN_SECRET string // A shared secret between the client and memphis-rest-gateway for calculating the body signature.
+	HMAC_TOKEN_HASH   string // Hash algorithm for calculating the body signature, can be either sha256 or sha512.
+}
+
+type Stations_Config struct {
+	NAME             string // Station name.
+	AUTH_METHOD      string // Either "jwt", "api_token" , "hmac_token" or "none".
+	JWT_Config              // JWT authentication settings.
+	API_Token_Config        // API Token authentication settings.
+}
+
 type Configuration struct {
-	VERSION                        string
-	JWT_SECRET                     string
-	JWT_EXPIRES_IN_MINUTES         int
-	REFRESH_JWT_SECRET             string
-	REFRESH_JWT_EXPIRES_IN_MINUTES int
-	HTTP_PORT                      string
-	ROOT_USER                      string
-	CONNECTION_TOKEN               string
-	MEMPHIS_HOST                   string
-	DEV_ENV                        string
-	CLIENT_CERT_PATH               string
-	CLIENT_KEY_PATH                string
-	ROOT_CA_PATH                   string
-	USER_PASS_BASED_AUTH           bool
-	ROOT_PASSWORD                  string
-	DEBUG                          bool
+	VERSION              string            // Configuration version
+	HTTP_PORT            string            // The port for the rest-gateway.
+	MEMPHIS_HOST         string            // Memphis host eithe IP or FQDN.
+	ROOT_CA_PATH         string            // Root CA of the Memphis server.
+	CLIENT_CERT_PATH     string            // The rest-gateway certificate.
+	CLIENT_KEY_PATH      string            // The rest-gateway privuate key.
+	USER_PASS_BASED_AUTH bool              // If true, the initial connection to Memphis uses username and password for authentication, otherwise a connection token is used.
+	ROOT_USER            string            // The username to use when USER_PASS_BASED_AUTH is true.
+	ROOT_PASSWORD        string            // The password to use when USER_PASS_BASED_AUTH is true.
+	CONNECTION_TOKEN     string            // The connection to use when USER_PASS_BASED_AUTH is false.
+	DEV_ENV              string            // If "true", enables the /monitoring/getResourcesUtilization route.
+	DEBUG                bool              // If true, enabled debug messages.
+	AUTH_METHOD          string            // Global auth method, can be either "jwt", "api_token", "hmac_token" or "none".
+	JWT_Config                             // Global jwt configuration if auth method is "jwt".
+	API_Token_Config                       // Global api token configuration if auth method is either "api_token" or "hmac_token".
+	Stations             []Stations_Config // Individual authentication method configuration for individual stations.
+
 }
 
 func GetConfig() Configuration {
 	configuration := Configuration{}
-	gonfig.GetConf("./conf/config.json", &configuration)
-
+	GonfigGetConf("./conf/config.json", &configuration)
 	return configuration
+}
+
+func ValidateAuthMethod(cfg Configuration) error {
+	switch cfg.AUTH_METHOD {
+	case "jwt":
+		if cfg.JWT_SECRET == "" {
+			return fmt.Errorf("JWT_SECRET is either the empty string or missing")
+		}
+		if cfg.REFRESH_JWT_SECRET == "" {
+			return fmt.Errorf("REFRESH_JWT_SECRET is either the empty string or missing")
+		}
+
+	case "api_token":
+		if cfg.API_TOKEN == "" {
+			return fmt.Errorf("API_TOKEN is either the empty string or missing")
+		}
+		if cfg.API_TOKEN_HEADER == "" {
+			return fmt.Errorf("API_TOKEN_HEADER is either the empty string or missing")
+		}
+
+	case "hmac_token":
+		if cfg.HMAC_TOKEN_SECRET == "" {
+			return fmt.Errorf("HMAC_TOKEN_SECRET is either the empty string or missing")
+		}
+		if cfg.HMAC_TOKEN_HEADER == "" {
+			return fmt.Errorf("HMAC_TOKEN_HEADER is either the empty string or missing")
+		}
+		if cfg.HMAC_TOKEN_HASH == "" {
+			return fmt.Errorf("HMAC_TOKEN_HMAC_HASH is either the empty string or missing")
+		}
+	case "none":
+		return nil
+	default:
+		if cfg.AUTH_METHOD == "" {
+			return nil
+		} else {
+			return fmt.Errorf("AUTH_METHOD is '%v' but must be either 'jwt', 'api_token', 'hmac_token' or 'none'", cfg.AUTH_METHOD)
+		}
+	}
+	return nil
+}
+
+func ValidateAuthMethodStation(cfg Stations_Config) error {
+	switch cfg.AUTH_METHOD {
+	case "jwt":
+		if cfg.JWT_SECRET == "" {
+			return fmt.Errorf("JWT_SECRET is either the empty string or missing")
+		}
+		if cfg.REFRESH_JWT_SECRET == "" {
+			return fmt.Errorf("REFRESH_JWT_SECRET is either the empty string or missing")
+		}
+
+	case "api_token":
+		if cfg.API_TOKEN == "" {
+			return fmt.Errorf("API_TOKEN is either the empty string or missing")
+		}
+		if cfg.API_TOKEN_HEADER == "" {
+			return fmt.Errorf("API_TOKEN_HEADER is either the empty string or missing")
+		}
+
+	case "hmac_token":
+		if cfg.HMAC_TOKEN_SECRET == "" {
+			return fmt.Errorf("HMAC_TOKEN_SECRET is either the empty string or missing")
+		}
+		if cfg.HMAC_TOKEN_HEADER == "" {
+			return fmt.Errorf("HMAC_TOKEN_HEADER is either the empty string or missing")
+		}
+		if cfg.HMAC_TOKEN_HASH == "" {
+			return fmt.Errorf("HMAC_TOKEN_HMAC_HASH is either the empty string or missing")
+		}
+	case "none":
+		return nil
+	default:
+		return fmt.Errorf("AUTH_METHOD is '%v' but has to be either 'jwt', 'api_token', 'hmac_token' or 'none'", cfg.AUTH_METHOD)
+	}
+	return nil
+}
+
+func Validate(configuration Configuration) error {
+
+	err := ValidateAuthMethod(configuration)
+	if err != nil {
+		return err
+	}
+	if configuration.Stations != nil {
+		for i, station := range configuration.Stations {
+			if station.NAME == "" {
+				return fmt.Errorf("station '%v' is mising a name", i)
+			}
+			err = ValidateAuthMethodStation(station)
+			if err != nil {
+				return fmt.Errorf("station '%v' - %v", i, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/conf/gonfig.go
+++ b/conf/gonfig.go
@@ -1,0 +1,195 @@
+// Package gonfig implements simple configuration reading
+// from both JSON files and enviornment variables.
+
+package conf
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/ghodss/yaml"
+)
+
+// tag name to override the field name of an environment variable
+const envTagName = "env"
+
+// GonfigGetConf aggregates all the JSON and enviornment variable values
+// and puts them into the passed interface.
+func GonfigGetConf(filename string, configuration interface{}) (err error) {
+
+	configValue := reflect.ValueOf(configuration)
+	if typ := configValue.Type(); typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("configuration should be a pointer to a struct type")
+	}
+
+	err = getFromYAML(filename, configuration)
+	if err == nil {
+		getFromEnvVariables(configuration)
+	}
+
+	return
+}
+
+func getFromYAML(filename string, configuration interface{}) (err error) {
+
+	if len(filename) == 0 {
+		return
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(data, &configuration)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func getFromEnvVariables(configuration interface{}) {
+	typ := reflect.TypeOf(configuration)
+	// if a pointer to a struct is passed, get the type of the dereferenced object
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	for _, field := range reflect.VisibleFields(typ) {
+		if !field.Anonymous {
+			// check if we've got a field name override for the environment
+			tagContent := field.Tag.Get(envTagName)
+			value := ""
+			if len(tagContent) > 0 {
+				value = os.Getenv(tagContent)
+			} else {
+				value = os.Getenv(field.Name)
+			}
+
+			if len(value) > 0 {
+				s := reflect.ValueOf(configuration).Elem()
+				if s.Kind() == reflect.Struct {
+					// exported field
+					f := s.FieldByName(field.Name)
+					setValue(f, value)
+				}
+			}
+		}
+	}
+}
+
+func setValue(f reflect.Value, value string) {
+	// change value
+	kind := f.Kind()
+
+	if f.IsValid() && f.CanSet() {
+		// A Value can be changed only if it is
+		// addressable and was not obtained by
+		// the use of unexported struct fields.
+		if kind == reflect.Int || kind == reflect.Int64 {
+			setStringToInt(f, value, 64)
+		} else if kind == reflect.Int32 {
+			setStringToInt(f, value, 32)
+		} else if kind == reflect.Int16 {
+			setStringToInt(f, value, 16)
+		} else if kind == reflect.Uint || kind == reflect.Uint64 {
+			setStringToUInt(f, value, 64)
+		} else if kind == reflect.Uint32 {
+			setStringToUInt(f, value, 32)
+		} else if kind == reflect.Uint16 {
+			setStringToUInt(f, value, 16)
+		} else if kind == reflect.Bool {
+			setStringToBool(f, value)
+		} else if kind == reflect.Float64 {
+			setStringToFloat(f, value, 64)
+		} else if kind == reflect.Float32 {
+			setStringToFloat(f, value, 32)
+		} else if kind == reflect.String {
+			f.SetString(value)
+		} else if kind == reflect.Struct {
+			setJSONStringToStruct(f, value)
+		} else if kind == reflect.Slice || kind == reflect.Array {
+			setJSONStringToArray(f, value)
+		}
+	}
+
+}
+
+func setStringToInt(f reflect.Value, value string, bitSize int) {
+	convertedValue, err := strconv.ParseInt(value, 10, bitSize)
+
+	if err == nil {
+		if !f.OverflowInt(convertedValue) {
+			f.SetInt(convertedValue)
+		}
+	}
+}
+
+func setStringToUInt(f reflect.Value, value string, bitSize int) {
+	convertedValue, err := strconv.ParseUint(value, 10, bitSize)
+
+	if err == nil {
+		if !f.OverflowUint(convertedValue) {
+			f.SetUint(convertedValue)
+		}
+	}
+}
+
+func setStringToBool(f reflect.Value, value string) {
+	convertedValue, err := strconv.ParseBool(value)
+
+	if err == nil {
+		f.SetBool(convertedValue)
+	}
+}
+
+func setStringToFloat(f reflect.Value, value string, bitSize int) {
+	convertedValue, err := strconv.ParseFloat(value, bitSize)
+
+	if err == nil {
+		if !f.OverflowFloat(convertedValue) {
+			f.SetFloat(convertedValue)
+		}
+	}
+}
+
+func setJSONStringToStruct(f reflect.Value, value string) {
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal([]byte(value), &jsonMap)
+	if err != nil {
+		fmt.Errorf("Cannot decode string into map") // Why isn't the error returned?
+	}
+
+	for k, v := range jsonMap {
+		subField := f.Addr().Elem().FieldByName(k)
+		setValue(subField, fmt.Sprintf("%v", v))
+	}
+}
+
+func setJSONStringToArray(f reflect.Value, value string) {
+	var jsonArr []interface{}
+	err := json.Unmarshal([]byte(value), &jsonArr)
+	if err != nil {
+		fmt.Errorf("Cannot decode string into array") // Why isn't the error returned?
+		return
+	}
+
+	f.Set(reflect.MakeSlice(f.Type(), len(jsonArr), len(jsonArr)))
+	for i, v := range jsonArr {
+		jsonItemVal, err := json.Marshal(v)
+		if err != nil {
+			fmt.Errorf("Cannot marshall array item element") // Why isn't the error returned?
+			return
+		}
+		setValue(f.Index(i), string(jsonItemVal[:]))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,16 @@ module rest-gateway
 go 1.18
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/gofiber/fiber/v2 v2.40.1
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/memphisdev/memphis.go v0.2.2
 	github.com/nats-io/nats.go v1.25.0
-	github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f h1:xDFq4NVQD34ekH5UsedBSgfxsBuPU2aZf7v4t0tH2jY=
-github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f/go.mod h1:DaZPBuToMc2eezA9R9nDAnmS2RMwL7yEa5YD36ESQdI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.41.0 h1:zeR0Z1my1wDHTRiamBCXVglQdbUwgb9uWG3k1HQz6jY=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"rest-gateway/conf"
 	"rest-gateway/logger"
 	"rest-gateway/router"
@@ -12,6 +14,17 @@ import (
 
 func main() {
 	configuration := conf.GetConfig()
+	err := conf.Validate(configuration)
+	if err != nil {
+		configurationJSON, marshalError := json.MarshalIndent(configuration, "", "  ")
+		if marshalError != nil {
+			panic(marshalError)
+		}
+		fmt.Printf("Configuration: %s\n", string(configurationJSON))
+		log.Fatalf("Configuration error: %v", err)
+		return
+	}
+
 	var conn *memphis.Conn
 	ticker := time.NewTicker(1 * time.Second)
 	for {
@@ -46,7 +59,6 @@ serverInit:
 	if err != nil {
 		panic("Logger creation failed - " + err.Error())
 	}
-
 	app := router.SetupRoutes(conn, l)
 	l.Noticef("Memphis REST gateway is up and running")
 	l.Noticef("Version %s", configuration.VERSION)

--- a/router/auth.go
+++ b/router/auth.go
@@ -8,8 +8,12 @@ import (
 )
 
 func InitilizeAuthRoutes(app *fiber.App) {
+
 	authHandler := handlers.AuthHandler{}
 	api := app.Group("/auth", logger.New())
 	api.Post("/authenticate", authHandler.Authenticate)
 	api.Post("/refreshToken", authHandler.RefreshToken)
+	api.Post("/authenticate/:stationName", authHandler.Authenticate)
+	api.Post("/refreshToken/:stationName", authHandler.RefreshToken)
+
 }

--- a/router/monitoring.go
+++ b/router/monitoring.go
@@ -1,10 +1,11 @@
 package router
 
 import (
-	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/logger"
 	"rest-gateway/conf"
 	"rest-gateway/handlers"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/logger"
 )
 
 func InitilizeMonitoringRoutes(app *fiber.App) {

--- a/router/router.go
+++ b/router/router.go
@@ -17,12 +17,38 @@ func SetupRoutes(conn *memphis.Conn, l *logger.Logger) *fiber.App {
 		DisableStartupMessage: true,
 	})
 
+	// Flag to track if a specific route has been matched
+	routeMatched := false
+
 	logger.SetLogger(app, l)
 	app.Use(cors.New())
-	app.Use(middlewares.Authenticate)
+
+	app.Post("/stations/:stationName/produce/single", func(c *fiber.Ctx) error {
+		return middlewares.AuthenticateStation(c, &routeMatched)
+	})
+	app.Post("/stations/:stationName/produce/batch", func(c *fiber.Ctx) error {
+		return middlewares.AuthenticateStation(c, &routeMatched)
+	})
 
 	InitilizeAuthRoutes(app)
+
+	// Register default middleware for unmatched routes. The order is important, this has to be called after InitilizeAuthRoutes().
+	app.Use(func(c *fiber.Ctx) error {
+		// Check if a specific route has been matched
+		if !routeMatched {
+			// Apply default middleware logic for unmatched routes
+			return middlewares.Authenticate(c)
+		}
+
+		// Reset the routeMatched flag for subsequent requests
+		routeMatched = false
+
+		// Continue processing the request
+		return c.Next()
+	})
+
 	InitializeStationsRoutes(app, conn)
 	InitilizeMonitoringRoutes(app)
+
 	return app
 }


### PR DESCRIPTION
Added configuration option so that as station can use its own authentication method.
The new configuration is backward compatible with previous versions so a user who doesn't want to use the new features can still use their old configuration file.

The package github.com/tkanos/gonfig doesn't handle embedded structs, so I patch it and added the patcher version directly in conf/gonfig.go. I have informed the people behind github.com/tkanos/gonfig about the bug and how I fixed it, so maybe the'll add the fix to their package.

I have tried to document the changes and provided examples on how to use  various configuration options.

