### PR TITLE
feat: add support for access token generation and authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,3 +46,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+// TODO: remove this once sdk changes are released
+replace github.com/memphisdev/memphis.go => ../memphis.go

--- a/handlers/consumer.go
+++ b/handlers/consumer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"rest-gateway/logger"
 	"rest-gateway/models"
-	"strconv"
 	"strings"
 	"time"
 
@@ -65,36 +64,14 @@ func ConsumeHandleMessage() func(*fiber.Ctx) error {
 				"error":   "Server error",
 			})
 		}
-		username := userData.Username
-		accountId := userData.AccountId
-		accountIdStr := strconv.Itoa(int(accountId))
-		conn := ConnectionsCache[accountIdStr][username].Connection
-		if conn == nil {
-			conn, err = Connect(userData.Password, username, userData.ConnectionToken, int(accountId))
-			if err != nil {
-				errMsg := strings.ToLower(err.Error())
-				if strings.Contains(errMsg, ErrorMsgAuthorizationViolation) || strings.Contains(errMsg, "token") || strings.Contains(errMsg, ErrorMsgMissionAccountId) {
-					log.Warnf("Could not establish new connection with the broker: Authentication error")
-					return c.Status(401).JSON(fiber.Map{
-						"message": "Unauthorized",
-					})
-				}
 
-				log.Errorf("Could not establish new connection with the broker: %s", err.Error())
-				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-					"message": "Server error",
-				})
-			}
-			if ConnectionsCache[accountIdStr] == nil {
-				ConnectionsCacheLock.Lock()
-				ConnectionsCache[accountIdStr] = make(map[string]Connection)
-				ConnectionsCacheLock.Unlock()
-			}
-
-			ConnectionsCacheLock.Lock()
-			ConnectionsCache[accountIdStr][username] = Connection{Connection: conn, ExpirationTime: userData.TokenExpiry}
-			ConnectionsCacheLock.Unlock()
+		conn, errorCode, err := getConnectionForUserData(userData)
+		if err != nil {
+			return c.Status(errorCode).JSON(fiber.Map{
+				"message": err.Error(),
+			})
 		}
+
 		reqBody.initializeDefaults()
 		msgs, err := conn.FetchMessages(stationName, reqBody.ConsumerName,
 			memphis.FetchBatchSize(reqBody.BatchSize),

--- a/models/auth.go
+++ b/models/auth.go
@@ -8,10 +8,16 @@ type AuthSchema struct {
 	RefreshTokenExpiryMins int     `json:"refresh_token_expiry_in_minutes"`
 	AccountId              float64 `json:"account_id"`
 	TokenExpiry            int64   `json:"token_expiry"`
+	AccessKeyID            string  `json:"access_key_id"`
+	SecretKey              string  `json:"secret_key"`
 }
 
 type RefreshTokenSchema struct {
 	JwtRefreshToken        string `json:"jwt_refresh_token"`
 	TokenExpiryMins        int    `json:"token_expiry_in_minutes"`
 	RefreshTokenExpiryMins int    `json:"refresh_token_expiry_in_minutes"`
+}
+
+type GenerateAccessTokenSchema struct {
+	Description string `json:"description"`
 }

--- a/router/auth.go
+++ b/router/auth.go
@@ -12,4 +12,5 @@ func InitilizeAuthRoutes(app *fiber.App) {
 	api := app.Group("/auth", logger.New())
 	api.Post("/authenticate", authHandler.Authenticate)
 	api.Post("/refreshToken", authHandler.RefreshToken)
+	api.Post("/generateAccessToken", authHandler.GenerateAccessToken)
 }


### PR DESCRIPTION
## Context
* This PR contains feature to create access tokens and authenticate request via access token (which are stored in broker) 

## Issue & Relevant PRs
* This enhancements will be subpart of following issue https://github.com/memphisdev/memphis-rest-gateway/issues/51
* Following are relevant PRs
    1. https://github.com/memphisdev/memphis/pull/1342
    2. https://github.com/memphisdev/memphis.go/pull/126

## Examples
Generate New Access Token
```
curl --location 'http://localhost:4444/auth/generateAccessToken' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoxLCJjb25uZWN0aW9uX3Rva2VuIjoiIiwiZXhwIjoyMDU1MzAxMTkwLCJwYXNzd29yZCI6Im1lbXBoaXMiLCJ1c2VybmFtZSI6InJvb3QifQ.HCJvG-UQG2kDNNlNlOovbLIf8E6VHPYAaV3JYnDo8Gc' \
--header 'Content-Type: application/json' \
--header 'Cookie: memphis-jwt-refresh-token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbHJlYWR5X2xvZ2dlZF9pbiI6dHJ1ZSwiYXZhdGFyX2lkIjoxLCJjcmVhdGlvbl9kYXRlIjoiMjAyMy0wOS0xOVQxNTozNjo1Mi42NzI1MTErMDU6MzAiLCJleHAiOjE2OTU0NjkyNjcsInRlbmFudF9uYW1lIjoiJG1lbXBoaXMiLCJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJyb290IiwidXNlcm5hbWUiOiJyb290In0.dhJXniH4V7Xh3t7w7e6Ow161GfR7e0hR-M6SYj9ELS4' \
--data '{
    "description": "New Access Tokens from gateway"
}
'
```
Output
```
{
    "access_key_id": "rAgfLcvAftjqTOu",
    "secret_key": "BsNjQDqBlxaRbjYyaBviLfYPu3iH1d"
}
```

Use Access Token in other requests instead of JWT
```
curl --location 'http://localhost:4444/stations/s1/produce/single' \
--header 'Access-Key-Id: rAgfLcvAftjqTOu' \
--header 'Secret-Key: BsNjQDqBlxaRbjYyaBviLfYPu3iH1d' \
--header 'Content-Type: application/json' \
--header 'Cookie: memphis-jwt-refresh-token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhbHJlYWR5X2xvZ2dlZF9pbiI6dHJ1ZSwiYXZhdGFyX2lkIjoxLCJjcmVhdGlvbl9kYXRlIjoiMjAyMy0wOS0xOVQxNTozNjo1Mi42NzI1MTErMDU6MzAiLCJleHAiOjE2OTU0NjkyNjcsInRlbmFudF9uYW1lIjoiJG1lbXBoaXMiLCJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJyb290IiwidXNlcm5hbWUiOiJyb290In0.dhJXniH4V7Xh3t7w7e6Ow161GfR7e0hR-M6SYj9ELS4' \
--data '{
    "message":"With Access Token yooohoo, its working!!!"
}'
```
Output
```
{
    "error": null,
    "success": true
}
```