### PR TITLE
unclear return type for auth/authenticate  and auth/refreshToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you are using Memphis **Cloud**, it is already in.
 Please create a JWT token, which will be part of each produce/consume request. For authentication purposes.
 
 * The generated JWT will encapsulate all the needed information for the broker to ensure the requester is authenticated to communicate with Memphis.
-* JWT token (by design) has an expiration time. Token refreshment can take place progrematically, but as it is often used to integrate memphis with other systems which are not supporting JWT refreshment, a workaround to overcome it would be to set a very high value in the `token_expiry_in_minutes`.
+* JWT token (by design) has an expiration time. Token refreshment can take place programmatically, but as it is often used to integrate memphis with other systems which are not supporting JWT refreshment, a workaround to overcome it would be to set a very high value in the `token_expiry_in_minutes`.
 * The default expiry time is 15 minutes.
 
 **Cloud (Using body params)**<br>

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -169,9 +169,9 @@ func (ah AuthHandler) Authenticate(c *fiber.Ctx) error {
 
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
 		"jwt":                      token,
-		"expires_in":               tokenExpiry * 60 * 1000,
+		"expires_at":               tokenExpiry,
 		"jwt_refresh_token":        refreshToken,
-		"refresh_token_expires_in": refreshTokenExpiry * 60 * 1000,
+		"refresh_token_expires_at": refreshTokenExpiry,
 	})
 }
 
@@ -276,9 +276,9 @@ func (ah AuthHandler) RefreshToken(c *fiber.Ctx) error {
 	ConnectionsCacheLock.Unlock()
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
 		"jwt":                      token,
-		"expires_in":               tokenExpiry * 60 * 1000,
+		"expires_at":               tokenExpiry,
 		"jwt_refresh_token":        refreshToken,
-		"refresh_token_expires_in": refreshTokenExpiry * 60 * 1000,
+		"refresh_token_expires_at": refreshTokenExpiry,
 	})
 }
 


### PR DESCRIPTION
When creating a token (and refreshing), you will receive the following JSON response:
```json
{
    "expires_in": 102800324040000,
    "jwt": "xxx",
    "jwt_refresh_token": "yyy",
    "refresh_token_expires_in": 102800324040000
}
```

The expires_in and refresh_token_expires_in values are actually Unix timestamps of the expiration time, multiplied by 60 and then by 1000. This information might not be explicitly mentioned in the documentation and can be confusing.

Your proposal to either update the documentation or change the field names to expires_at and refresh_token_expires_at, using Unix timestamps directly, seems like a practical improvement.